### PR TITLE
Update RankFilter.pm

### DIFF
--- a/RankFilter.pm
+++ b/RankFilter.pm
@@ -86,7 +86,7 @@ sub new {
 }
 
 sub feature_types {
-    return ['Transcript'];
+    return ['Feature', 'Intergenic'];
 }
 
 sub include_line {


### PR DESCRIPTION
Changing the feature_types to Feature and Intergenic will make this plugin extensible to non-transcript-overlapping variants as well.